### PR TITLE
dont call native blur when tabbing out

### DIFF
--- a/src/InputManager.ts
+++ b/src/InputManager.ts
@@ -146,8 +146,8 @@ module Coveo.MagicBox {
     */
     public setCursor(index: number) {
       this.input.focus();
-      if (this.input.createTextRange) {
-        var range = this.input.createTextRange();
+      if ((<any>this.input).createTextRange) {
+        var range = (<any>this.input).createTextRange();
         range.move("character", index);
         range.select();
       } else if (this.input.selectionStart != null) {
@@ -216,12 +216,8 @@ module Coveo.MagicBox {
     private keydown(e: KeyboardEvent) {
       switch (e.keyCode || e.which) {
         case 9: // Tab key
-          if (!this.justPressedTab) {
-            if (this.magicBox.hasSuggestions()) {
-              e.preventDefault();
-            }
-          } else {
-            this.blur();
+          if (!this.justPressedTab && this.magicBox.hasSuggestions()) {
+            e.preventDefault();
           }
           this.justPressedTab = true;
           break;


### PR DESCRIPTION
Removed a call to the native method `input.blur` when tabbing out of the input box. It is not necessary as in this case, we are tabbing out of the input box. All events are properly fired without calling the native method.

This caused the focus to be stuck in the input in IE11. Calling [`blur`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) removes the focus from the element and in the case of the searchbox input, switches the focus to the body element. When tabbing, the focus would go back in the search box which caused the loop.
 
This doesn't cause an issue in other browsers as it seems that when re-entering the body element, the browser remembers where it left off and passes the focus on the element that follows the input box in the focus order. 