### PR TITLE
Accept decimal number

### DIFF
--- a/src/Grammars/Basic.ts
+++ b/src/Grammars/Basic.ts
@@ -10,7 +10,7 @@ module Coveo.MagicBox.Grammars {
       NotDoubleQuote: /[^"]*/,
       SingleQuoted: "'[NotSingleQuote]'",
       NotSingleQuote: /[^']*/,
-      Number: /[0-9]+/,
+      Number: /-?(0|[1-9]\d*)(\.\d+)?/,
       Word: (input: string, end: boolean, expression: Expression) => {
         var regex = new RegExp('[^' + notWordStart.replace(/(.)/g, '\\$1') + '][^' + notInWord.replace(/(.)/g, '\\$1') + ']*');
         var groups = input.match(regex);

--- a/test/GrammarTest.ts
+++ b/test/GrammarTest.ts
@@ -378,6 +378,22 @@ describe('Coveo Field Grammar parse correctly', () => {
     var result = coveoGrammar.parse('@fieldName<420');
     expect(result.isSuccess()).toBeTruthy();
   });
+  it('"@fieldName<4.20"', () => {
+    var result = coveoGrammar.parse('@fieldName<4.20');
+    expect(result.isSuccess()).toBeTruthy();
+  });
+  it('"@fieldName<4,20"', () => {
+    var result = coveoGrammar.parse('@fieldName<4,20');
+    expect(result.isSuccess()).toBeFalsy();
+  });
+  it('"@fieldName<-4.20"', () => {
+    var result = coveoGrammar.parse('@fieldName<-4.20');
+    expect(result.isSuccess()).toBeTruthy();
+  });
+  it('"@fieldName<4.20.20"', () => {
+    var result = coveoGrammar.parse('@fieldName<4.20.20');
+    expect(result.isSuccess()).toBeFalsy();
+  });
   it('@fieldName>=2000/01/01', ()=>{
     var result = coveoGrammar.parse('@fieldName>=2000/01/01');
     expect(result.isSuccess()).toBeTruthy();


### PR DESCRIPTION
For numbers, coveo index normally accepts 

```
@size>10
@size>-10
@size>10.5
@size>-10.5
```
Should not accept : 
```
@size>10,5
@size>10.5.5
```

This regex change should cover those use cases

https://coveord.atlassian.net/browse/JSUI-1823